### PR TITLE
Hugo 0.41 [DO NOT MERGE]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,8 @@ RUN set -ex && \
   tar -xf go-ipfs_v${IPFS_VERSION}_linux-amd64.tar.gz && \
   mv go-ipfs/ipfs /usr/bin/ipfs
 
-# Install aegir, godoc2md, dnslink-dnsimple
+# Install godoc2md, dnslink-dnsimple
 RUN set -ex && \
-  npm install -g aegir && \
   go get -v github.com/lgierth/dnslink-dnsimple && \
   go get -v github.com/davecheney/godoc2md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV IPFS_API /ip4/127.0.0.1/tcp/5001
 ENV DNSIMPLE_TOKEN ""
 
 ENV IPFS_VERSION 0.4.13
-ENV HUGO_VERSION 0.31.1
+ENV HUGO_VERSION 0.41
 
 # Install nodejs and npm
 RUN set -ex && \


### PR DESCRIPTION
[DO NOT MERGE] as this changes the default hugo version (which would break builds for ipfs/website)

@lgierth unsure of why aegir is installed globally here, the websites should run `npm install` in their `Makefile` which installs `aegir` if it's required for building the project.

Another thing I'm unsure is how we can maintain different versions of Hugo + go-ipfs and have those images deployed on Docker Hub.