### PR TITLE
feat: build docker image on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,88 @@
+version: 2.1
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: ipfs/ci-websites
+    docker:
+      - image: circleci/buildpack-deps:stretch
+jobs:
+  build:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t $IMAGE_NAME:latest .
+      - run:
+          name: Archive Docker image
+          command: docker save -o image.tar $IMAGE_NAME
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./image.tar
+  publish-latest:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            IMAGE_TAG="latest-${CIRCLE_BUILD_NUM}"
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
+  publish-tag:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Publish Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            IMAGE_TAG=${CIRCLE_TAG/v/''}
+            docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
+            docker push $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:$IMAGE_TAG
+workflows:
+  version: 2
+  build-master:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master
+      - publish-latest:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+  build-tags:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v?\d+\.\d+/
+            branches:
+              ignore: /.*/
+      - publish-tag:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v?\d+\.\d+/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CircleCI](https://circleci.com/gh/ipfs/ci-websites.svg?style=svg)](https://circleci.com/gh/ipfs/ci-websites)
 
-Has Go and JS installed.
+Has Go and JS installed. Used by https://github.com/ipfs/docs
 
 ```console
 # build the image

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 > Docker container that builds our websites.
 
+[![CircleCI](https://circleci.com/gh/ipfs/ci-websites.svg?style=svg)](https://circleci.com/gh/ipfs/ci-websites)
+
 Has Go and JS installed.
 
-```sh
-> docker run -it -v /path/to/repo:/site ipfs/ci-websites make -C /site build
+```console
+# build the image
+$ docker build . -t ipfs/ci-websites
+
+# run the build process for the website at /path/to/repo
+$ docker run -it -v /path/to/repo:/site ipfs/ci-websites make -C /site build
 ```


### PR DESCRIPTION
dockerhub has terrible github permission handling. We'd need to make @ipfsbot an org admin to set up docker auto builds for this repo. 

This will
- update the `latest` tag on dockerhub when we merge to master
- add version tags on dockerhub when we add tags on git in the form `v1.0.0`

This code copied almost entirely from https://circleci.com/blog/using-circleci-workflows-to-replicate-docker-hub-automated-builds/ though i took the liberty of tightening up the version regex, and removing the wacky semver for latest tags.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>